### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
           echo ${{ steps.vars.outputs.tag }}
       - uses: actions/checkout@v1
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           registry: cr-hn-1.vccloud.vn
           name: cr-hn-1.vccloud.vn/31ff9581861a4d0ea4df5e7dda0f665d/bizfly-cloud-controller-manager:${{ steps.vars.outputs.tag }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore